### PR TITLE
Fixing undefined symbols in libgraphfl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 module1 = Extension('libgraphfl',
                     include_dirs = ['cpp/include/'],
                     libraries=['gsl', 'gslcblas'],
-                    sources = ['cpp/src/graph_fl.c', 'cpp/src/tf_dp.c'])
+                    sources = ['cpp/src/bayes_gfl.c', 'cpp/src/csparse.c', 'cpp/src/graph_fl.c', 'cpp/src/graph_tf.c', 'cpp/src/polyagamma.c', 'cpp/src/tf_dp.c', 'cpp/src/utils.c'])
 
 setup(
     name='pygfl',


### PR DESCRIPTION
Include all c files when building libgraphfl.

Now need automatic way to locate gsl and use proper CFLAGS, i.e. using gsl-config --cflags --libs